### PR TITLE
Fix CI pipeline failure by configuring TypeScript 6 alongside TypeScript 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
         "rollup": "^4.59.0",
         "rollup-plugin-dts": "^6.4.0",
         "tslib": "^2.8.1",
-        "typescript": "^7.0.2",
+        "typescript": "npm:@typescript/typescript6@^6.0.2",
+        "typescript-native": "npm:typescript@^7.0.2",
         "vitest": "^4.1.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,6 +574,11 @@
     "@typescript-eslint/types" "8.64.0"
     eslint-visitor-keys "^5.0.0"
 
+"@typescript/old@npm:typescript@^6":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
 "@typescript/typescript-aix-ppc64@7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz#cdc7ce81d60f1e09034960ddfb1fb880d7a776b6"
@@ -1485,7 +1490,7 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
-typescript@^7.0.2:
+"typescript-native@npm:typescript@^7.0.2":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-7.0.2.tgz#9ec773d7954a8c182c17cc5bbd575aa28bc51582"
   integrity sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==
@@ -1510,6 +1515,13 @@ typescript@^7.0.2:
     "@typescript/typescript-sunos-x64" "7.0.2"
     "@typescript/typescript-win32-arm64" "7.0.2"
     "@typescript/typescript-win32-x64" "7.0.2"
+
+"typescript@npm:@typescript/typescript6@^6.0.2":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@typescript/typescript6/-/typescript6-6.0.2.tgz#79e0e47492564c83f8602013d7dd10d5ebc51a8c"
+  integrity sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==
+  dependencies:
+    "@typescript/old" "npm:typescript@^6"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Fix CI pipeline failure caused by upgrading to TypeScript 7. Configured TypeScript 6 side-by-side with TypeScript 7 via npm aliases so that tooling (such as eslint and rollup plugin) remains fully compatible.

---
*PR created automatically by Jules for task [11052739511637980626](https://jules.google.com/task/11052739511637980626) started by @allemandi*