### PR TITLE
Fix npm publish workflow failing on EBADENGINE error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn lint
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn build
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org/'
           cache: 'yarn'
 
@@ -32,5 +32,4 @@ jobs:
       # npm publish using OIDC (Yarn publish cannot use OIDC)
       - name: Publish to npm
         run: |
-          npm install -g npm@latest
           npm publish --provenance --access public


### PR DESCRIPTION
Upgraded Node.js from version 20 to 22 in both the CI (`ci.yml`) and Publish (`publish.yml`) GitHub Action workflows. Additionally, removed the redundant `npm install -g npm@latest` step from `publish.yml` to prevent future `EBADENGINE` unsupported engine errors when a new major version of npm is released. Verified that all lint, build, test, and smoke tests pass seamlessly.

---
*PR created automatically by Jules for task [11225394007452178027](https://jules.google.com/task/11225394007452178027) started by @allemandi*